### PR TITLE
Adds a "pred" macro for better filter definition

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,15 +3,16 @@
   :url "https://github.com/alexrobbins/parquet-thrift-cascalog"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :plugins [[lein-thriftc "0.2.1"]
-            [lein-midje "3.1.3"]]
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [cascalog "2.1.1"]
-                 [com.twitter/parquet-cascading "1.6.0rc4"]]
-  :hooks [leiningen.thriftc]
-  :thriftc {:source-paths ["test/thrift"]}
+  :dependencies [[com.twitter/parquet-cascading "1.6.0rc4"]
+                 [org.clojure/clojure "1.6.0"]
+                 [org.clojure/tools.macro "0.1.2"]
+                 [cascalog "2.1.1"]]
   :profiles {:dev {:dependencies [[midje "1.6.3"]
-                                  [cascalog/midje-cascalog "2.1.1"]]}
+                                  [cascalog/midje-cascalog "2.1.1"]]
+                   :plugins [[lein-thriftc "0.2.1"]
+                             [lein-midje "3.1.3"]]
+                   ;; :hooks [leiningen.thriftc]
+                   :thriftc {:source-paths ["test/thrift"]}}
              :provided {:dependencies [[org.apache.hadoop/hadoop-core "1.1.2"]
                                        [org.apache.thrift/libthrift "0.9.2"
                                         :exclusions [org.slf4j/slf4j-api]]]}})

--- a/test/parquet_thrift_cascalog/filter_test.clj
+++ b/test/parquet_thrift_cascalog/filter_test.clj
@@ -1,0 +1,12 @@
+(ns parquet-thrift-cascalog.core-test
+  (:require [clojure.test :refer :all]
+            [parquet-thrift-cascalog.filter :as f]))
+
+(deftest pred-generation-test
+  (testing "the pred form translates its guts into Parquet filters."
+    (is (= (f/and (f/not (f/lt "face" 10))
+                  (f/gtEq "face" 13))
+           (f/pred
+            (let [column-name "face"]
+              (and (not (< column-name 10))
+                   (>= column-name 13))))))))

--- a/test/parquet_thrift_cascalog/filter_test.clj
+++ b/test/parquet_thrift_cascalog/filter_test.clj
@@ -10,3 +10,13 @@
             (let [column-name "face"]
               (and (not (< column-name 10))
                    (>= column-name 13))))))))
+
+(deftest column-creation-test
+  (let [original (f/column 10 "col")
+        cloned (f/column original "new-name")]
+    (is (= Long
+           (.getColumnType original)
+           (.getColumnType cloned))
+        "The cloned column has the same type as the original..")
+    (is (= "col" (.toDotString (.getColumnPath original))))
+    (is (= "new-name" (.toDotString (.getColumnPath cloned)))))  )


### PR DESCRIPTION
The code looked pretty good. I added two main items:
### Column Protocol

The "column" protocol that allows you to define a column based on some comparison value and a column name. The implementation dispatches on the type of the comparison value. For example:

``` clojure
parquet-thrift-cascalog.filter> (column (byte-array [1 2 3]) "bytes")
#<BinaryColumn column(bytes)>
parquet-thrift-cascalog.filter> (column 10 "face")
#<LongColumn column(face)>
```

It's also defined for a value that's already a column. That implementation just clones the column type but changes the column name:

``` clojure
parquet-thrift-cascalog.filter> (column (column 10 "face") "cake")
#<LongColumn column(cake)>
```

I DON'T have a String implementation defined, since Parquet doesn't give us a String column yet.
### "Pred" macro

Not a Cascalog predicate macro :) Just wanted to make things confusing.

The `pred` macro inside of the `filter` namespace allows you to use Clojure's `<=`, `<` etc comparators instead of `ltEq`, `lt` etc. The macro replaces the Clojure forms with the parquet forms, allowing you to declare filters like this:

``` clojure
parquet-thrift-cascalog.filter> 
(pred
 (or (> "cake" 100.234)
     (and (not (< "face" 10))
          (>= "face" 13))))
#<Or or(gt(cake, 100.234), and(not(lt(face, 10)), gteq(face, 13)))>
```

I added a test namespace for this too. I can add a few more tests if you're into this.
